### PR TITLE
Fix conversion error from string "1"

### DIFF
--- a/Firebird/sakila-schema.sql
+++ b/Firebird/sakila-schema.sql
@@ -560,7 +560,7 @@ SELECT
   a.phone AS phone,
   city.city AS city,
   country.country AS country,
-  case when cu.active=1 then 'active' else '' end AS notes,
+  case when cu.active=true then 'active' else '' end AS notes,
   cu.store_id AS SID
 FROM 
   customer AS cu 


### PR DESCRIPTION
Thanks for making this repo. It's awesome!

So, I ran into an error when listing `customer_list` view.

```sql
SELECT * FROM customer_list;
```

```
SQL Error [335544334] [22018]: conversion error from string "1" [SQLState:22018, ISC error code:335544334]
```

Looked into the source query, and I'm able to reproduce the same error.

Using firebird 4.0.1